### PR TITLE
fix issues #1 and #3: safety trinity + strict date parsing

### DIFF
--- a/core/src/main/java/io/getskipper/core/SheetsClient.java
+++ b/core/src/main/java/io/getskipper/core/SheetsClient.java
@@ -16,14 +16,12 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.time.Instant;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 /**
  * Reads test entries from a Google Sheets spreadsheet using a service account.
@@ -31,11 +29,7 @@ import java.util.Map;
 public final class SheetsClient {
 
     private static final String APPLICATION_NAME = "skipper-java";
-    private static final DateTimeFormatter DATE_ONLY = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-    private static final DateTimeFormatter DATE_TIME_UTC =
-            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'");
-    private static final DateTimeFormatter DATE_TIME_NO_TZ =
-            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+    private static final Pattern DATE_RE = Pattern.compile("^\\d{4}-\\d{2}-\\d{2}$");
 
     private final SkipperConfig config;
 
@@ -168,11 +162,7 @@ public final class SheetsClient {
                     && row.get(disabledUntilIdx) != null) {
                 String raw = row.get(disabledUntilIdx).toString().strip();
                 if (!raw.isBlank()) {
-                    disabledUntil = parseDate(raw);
-                    if (disabledUntil == null) {
-                        SkipperLogger.warn("Row " + (i + 1) + " in \"" + sheetName
-                                + "\": invalid date \"" + raw + "\" — treating test as enabled.");
-                    }
+                    disabledUntil = parseDate(raw, i + 1, sheetName);
                 }
             }
 
@@ -233,25 +223,33 @@ public final class SheetsClient {
         return -1;
     }
 
-    private static Instant parseDate(String s) {
-        // Try "yyyy-MM-dd" → treat as end-of-day UTC so the full day is disabled
-        try {
-            LocalDate date = LocalDate.parse(s, DATE_ONLY);
-            return date.atTime(23, 59, 59).toInstant(ZoneOffset.UTC);
-        } catch (DateTimeParseException ignored) {}
-
-        // Try "yyyy-MM-dd'T'HH:mm:ss'Z'"
-        try {
-            LocalDateTime dt = LocalDateTime.parse(s, DATE_TIME_UTC);
-            return dt.toInstant(ZoneOffset.UTC);
-        } catch (DateTimeParseException ignored) {}
-
-        // Try "yyyy-MM-dd'T'HH:mm:ss"
-        try {
-            LocalDateTime dt = LocalDateTime.parse(s, DATE_TIME_NO_TZ);
-            return dt.toInstant(ZoneOffset.UTC);
-        } catch (DateTimeParseException ignored) {}
-
-        return null;
+    /**
+     * Parses a {@code disabledUntil} date string.
+     *
+     * <p>Only {@code YYYY-MM-DD} is accepted. Malformed values throw immediately so bad
+     * spreadsheet data is caught at startup, not silently mid-run.
+     *
+     * <p>The returned instant is the start of the <em>following</em> UTC day, so a test
+     * marked disabled until {@code 2026-04-01} remains disabled through the end of that
+     * calendar day (UTC) and re-enables at {@code 2026-04-02T00:00:00Z}. This comparison
+     * is timezone-independent: {@code Instant.now().isBefore(result)} yields the same
+     * answer on every CI runner regardless of JVM default timezone.
+     *
+     * @param raw      raw cell value
+     * @param rowNum   1-based row number, used in the error message
+     * @param sheetName sheet name, used in the error message
+     * @return the expiry instant, or {@code null} if {@code raw} is null or blank
+     * @throws IllegalArgumentException if {@code raw} does not match {@code YYYY-MM-DD}
+     */
+    static Instant parseDate(String raw, int rowNum, String sheetName) {
+        if (raw == null || raw.isBlank()) return null;
+        String trimmed = raw.strip();
+        if (!DATE_RE.matcher(trimmed).matches()) {
+            throw new IllegalArgumentException(
+                    "[skipper] Row " + rowNum + " in \"" + sheetName
+                            + "\": invalid disabledUntil \"" + raw + "\". Use YYYY-MM-DD.");
+        }
+        LocalDate date = LocalDate.parse(trimmed);
+        return date.plusDays(1).atStartOfDay(ZoneOffset.UTC).toInstant();
     }
 }

--- a/core/src/main/java/io/getskipper/core/SheetsWriter.java
+++ b/core/src/main/java/io/getskipper/core/SheetsWriter.java
@@ -1,6 +1,10 @@
 package io.getskipper.core;
 
 import com.google.api.services.sheets.v4.Sheets;
+import com.google.api.services.sheets.v4.model.BatchUpdateSpreadsheetRequest;
+import com.google.api.services.sheets.v4.model.DeleteDimensionRequest;
+import com.google.api.services.sheets.v4.model.DimensionRange;
+import com.google.api.services.sheets.v4.model.Request;
 import com.google.api.services.sheets.v4.model.ValueRange;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -37,9 +41,15 @@ public final class SheetsWriter {
     }
 
     /**
-     * Appends any discovered test IDs that are not yet in the sheet.
-     * Existing rows are never deleted, making this operation safe to call from multiple
-     * Gradle test tasks in a multi-module build.
+     * Reconciles the spreadsheet with the test IDs discovered during a test run.
+     *
+     * <ul>
+     *   <li>Appends rows for test IDs not yet in the sheet.</li>
+     *   <li>Detects orphaned rows (IDs in the sheet that were not discovered). By default
+     *       these are logged but <em>not</em> deleted, making sync safe for multi-module
+     *       projects where different Gradle tasks each contribute a subset of the full suite.
+     *       Set {@code SKIPPER_SYNC_ALLOW_DELETE=true} to actually prune them.</li>
+     * </ul>
      *
      * @param discoveredTestIds all test IDs discovered during the test run
      */
@@ -55,11 +65,46 @@ public final class SheetsWriter {
         List<String> header = primary.header();
         int testIdColIdx = indexOf(header, config.testIdColumn());
 
+        Set<String> discoveredNormalized = new HashSet<>();
+        for (String id : discoveredTestIds) {
+            discoveredNormalized.add(TestIdHelper.normalize(id));
+        }
+
         Set<String> existingIds = new HashSet<>();
         for (TestEntry entry : primary.entries()) {
             existingIds.add(TestIdHelper.normalize(entry.testId()));
         }
 
+        // Detect orphaned rows (in sheet but not in discoveredTestIds).
+        // rawRows[0] is the header; data rows start at index 1.
+        List<Integer> orphanedRowIndices = new ArrayList<>();
+        List<List<Object>> rawRows = primary.rawRows();
+        for (int i = 1; i < rawRows.size(); i++) {
+            List<Object> row = rawRows.get(i);
+            if (testIdColIdx >= row.size()) continue;
+            Object cell = row.get(testIdColIdx);
+            if (cell == null) continue;
+            String id = cell.toString().strip();
+            if (id.isBlank()) continue;
+            if (!discoveredNormalized.contains(TestIdHelper.normalize(id))) {
+                orphanedRowIndices.add(i);
+            }
+        }
+
+        // Handle orphaned rows.
+        boolean allowDeletes = "true".equalsIgnoreCase(System.getenv("SKIPPER_SYNC_ALLOW_DELETE"));
+        if (!orphanedRowIndices.isEmpty()) {
+            if (!allowDeletes) {
+                SkipperLogger.logf("[skipper] %d orphaned row(s) found in \"%s\".",
+                        orphanedRowIndices.size(), sheetName);
+                SkipperLogger.log("[skipper] Set SKIPPER_SYNC_ALLOW_DELETE=true to prune them.");
+            } else {
+                deleteRows(spreadsheetId, primary.sheetId(), orphanedRowIndices);
+                SkipperLogger.logf("Sync: deleted %d orphaned row(s).", orphanedRowIndices.size());
+            }
+        }
+
+        // Append new test IDs.
         Set<String> toAdd = new LinkedHashSet<>();
         for (String id : discoveredTestIds) {
             if (!existingIds.contains(TestIdHelper.normalize(id))) {
@@ -68,7 +113,7 @@ public final class SheetsWriter {
         }
 
         if (toAdd.isEmpty()) {
-            SkipperLogger.log("Sync: spreadsheet is already up to date.");
+            SkipperLogger.log("Sync: no new test IDs to append.");
             return;
         }
 
@@ -85,6 +130,29 @@ public final class SheetsWriter {
                 .setValueInputOption("USER_ENTERED")
                 .execute();
         SkipperLogger.logf("Sync: appended %d new test ID(s).", toAdd.size());
+    }
+
+    /**
+     * Deletes the specified sheet rows (0-based indices) in a single batch update.
+     * Rows are deleted in reverse order so earlier indices remain valid after each deletion.
+     */
+    private void deleteRows(String spreadsheetId, int sheetId, List<Integer> rowIndices)
+            throws IOException {
+        List<Request> requests = new ArrayList<>();
+        // Iterate in reverse to avoid index shifting
+        for (int i = rowIndices.size() - 1; i >= 0; i--) {
+            int idx = rowIndices.get(i);
+            requests.add(new Request().setDeleteDimension(
+                    new DeleteDimensionRequest().setRange(
+                            new DimensionRange()
+                                    .setSheetId(sheetId)
+                                    .setDimension("ROWS")
+                                    .setStartIndex(idx)
+                                    .setEndIndex(idx + 1))));
+        }
+        service.spreadsheets()
+                .batchUpdate(spreadsheetId, new BatchUpdateSpreadsheetRequest().setRequests(requests))
+                .execute();
     }
 
     private static int indexOf(List<String> header, String column) {

--- a/core/src/main/java/io/getskipper/core/SkipperResolver.java
+++ b/core/src/main/java/io/getskipper/core/SkipperResolver.java
@@ -4,7 +4,10 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.services.sheets.v4.Sheets;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Instant;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -37,17 +40,100 @@ public final class SkipperResolver {
     /**
      * Fetches the spreadsheet and populates the in-memory cache.
      * Must be called before {@link #isTestEnabled(String)}.
+     *
+     * <p>Behaviour is controlled by three environment variables:
+     * <ul>
+     *   <li>{@code SKIPPER_CACHE_FILE} (default: {@code .skipper-cache.json}) — path to the
+     *       on-disk cache file that is written after every successful fetch.</li>
+     *   <li>{@code SKIPPER_CACHE_TTL} (default: {@code 300}) — maximum age in seconds for the
+     *       on-disk cache to be used as a fallback when the API is unreachable.</li>
+     *   <li>{@code SKIPPER_FAIL_OPEN} (default: {@code true}) — if the API fails <em>and</em>
+     *       no valid cache exists, run all tests instead of throwing. Set to {@code false} to
+     *       restore the original crash behaviour.</li>
+     * </ul>
      */
     public void initialize() throws IOException {
-        SheetsClient client = new SheetsClient(config);
-        FetchAllResult result = client.fetchAll();
-        this.sheetsService = result.service();
+        String cacheFile = System.getenv().getOrDefault("SKIPPER_CACHE_FILE", ".skipper-cache.json");
+        int cacheTtl = Integer.parseInt(
+                System.getenv().getOrDefault("SKIPPER_CACHE_TTL", "300"));
+        boolean failOpen = !"false".equalsIgnoreCase(
+                System.getenv().getOrDefault("SKIPPER_FAIL_OPEN", "true"));
 
-        cache = new HashMap<>();
-        for (TestEntry entry : result.entries()) {
-            cache.put(TestIdHelper.normalize(entry.testId()), entry.disabledUntil());
+        try {
+            SheetsClient client = new SheetsClient(config);
+            FetchAllResult result = client.fetchAll();
+            this.sheetsService = result.service();
+
+            cache = new HashMap<>();
+            for (TestEntry entry : result.entries()) {
+                cache.put(TestIdHelper.normalize(entry.testId()), entry.disabledUntil());
+            }
+            SkipperLogger.logf("Resolver initialized with %d cached entries.", cache.size());
+            writeCacheFile(cacheFile, cache);
+        } catch (Exception err) {
+            Map<String, Instant> fromCache = readCacheFile(cacheFile, cacheTtl);
+            if (fromCache != null) {
+                cache = fromCache;
+                SkipperLogger.logf("[skipper] API failed, using on-disk cache (%s).", cacheFile);
+                return;
+            }
+            if (failOpen) {
+                cache = Collections.emptyMap();
+                SkipperLogger.log("[skipper] API failed, no valid cache — running all tests (fail-open).");
+                return;
+            }
+            if (err instanceof IOException ioEx) throw ioEx;
+            throw new IOException("[skipper] Initialization failed", err);
         }
-        SkipperLogger.logf("Resolver initialized with %d cached entries.", cache.size());
+    }
+
+    /**
+     * Writes the current in-memory cache to disk as JSON so it can be used as a fallback
+     * on subsequent runs if the Sheets API is unavailable.
+     */
+    void writeCacheFile(String path, Map<String, Instant> entries) {
+        try {
+            Map<String, Object> payload = new HashMap<>();
+            payload.put("savedAt", Instant.now().toString());
+            Map<String, String> serialized = new HashMap<>();
+            for (Map.Entry<String, Instant> e : entries.entrySet()) {
+                serialized.put(e.getKey(), e.getValue() != null ? e.getValue().toString() : null);
+            }
+            payload.put("entries", serialized);
+            Files.writeString(Path.of(path), MAPPER.writeValueAsString(payload));
+        } catch (Exception e) {
+            SkipperLogger.warn("[skipper] Could not write cache file \"" + path + "\": " + e.getMessage());
+        }
+    }
+
+    /**
+     * Reads the on-disk cache file and returns the entries if the file exists and is within
+     * the TTL window. Returns {@code null} if the file is missing, unreadable, or expired.
+     */
+    static Map<String, Instant> readCacheFile(String path, int ttlSeconds) {
+        try {
+            String json = Files.readString(Path.of(path));
+            Map<String, Object> payload = MAPPER.readValue(json, new TypeReference<>() {});
+            String savedAtStr = (String) payload.get("savedAt");
+            if (savedAtStr == null) return null;
+            Instant savedAt = Instant.parse(savedAtStr);
+            long ageSeconds = Instant.now().getEpochSecond() - savedAt.getEpochSecond();
+            if (ageSeconds > ttlSeconds) {
+                SkipperLogger.logf("[skipper] Cache file \"%s\" is %ds old (TTL=%ds) — ignoring.",
+                        path, ageSeconds, ttlSeconds);
+                return null;
+            }
+            @SuppressWarnings("unchecked")
+            Map<String, String> raw = (Map<String, String>) payload.get("entries");
+            if (raw == null) return null;
+            Map<String, Instant> result = new HashMap<>();
+            for (Map.Entry<String, String> e : raw.entrySet()) {
+                result.put(e.getKey(), e.getValue() != null ? Instant.parse(e.getValue()) : null);
+            }
+            return result;
+        } catch (Exception e) {
+            return null;
+        }
     }
 
     /**

--- a/core/src/test/java/io/getskipper/core/SheetsClientDateParsingTest.java
+++ b/core/src/test/java/io/getskipper/core/SheetsClientDateParsingTest.java
@@ -1,0 +1,81 @@
+package io.getskipper.core;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class SheetsClientDateParsingTest {
+
+    @Test
+    void parseDate_nullReturnsNull() {
+        assertThat(SheetsClient.parseDate(null, 2, "Sheet1")).isNull();
+    }
+
+    @Test
+    void parseDate_blankReturnsNull() {
+        assertThat(SheetsClient.parseDate("   ", 2, "Sheet1")).isNull();
+    }
+
+    @Test
+    void parseDate_validDate_returnsStartOfNextDayUtc() {
+        Instant result = SheetsClient.parseDate("2026-04-01", 2, "Sheet1");
+        Instant expected = Instant.parse("2026-04-02T00:00:00Z");
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    void parseDate_validDate_testDisabledOnThatDay() {
+        // A test disabled until 2026-04-01 should still be disabled at 23:59 UTC that day.
+        Instant result = SheetsClient.parseDate("2026-04-01", 2, "Sheet1");
+        Instant justBeforeMidnight = Instant.parse("2026-04-01T23:59:59Z");
+        // disabled = result.isAfter(now), i.e. expiry has not passed yet
+        assertThat(result).isAfter(justBeforeMidnight);
+    }
+
+    @Test
+    void parseDate_validDate_testEnabledNextDay() {
+        // A test disabled until 2026-04-01 should be enabled at 00:00:01 on 2026-04-02 UTC.
+        Instant result = SheetsClient.parseDate("2026-04-01", 2, "Sheet1");
+        Instant startOfNextDay = Instant.parse("2026-04-02T00:00:01Z");
+        // enabled = !result.isAfter(now), i.e. expiry has passed
+        assertThat(result).isBefore(startOfNextDay);
+    }
+
+    @Test
+    void parseDate_timezoneConsistency() {
+        // The returned instant must be the same regardless of the JVM default timezone.
+        // We verify by checking it equals the known UTC value directly.
+        Instant result = SheetsClient.parseDate("2026-06-15", 3, "Sheet1");
+        assertThat(result).isEqualTo(
+                java.time.LocalDate.of(2026, 6, 16).atStartOfDay(ZoneOffset.UTC).toInstant());
+    }
+
+    @Test
+    void parseDate_malformedDate_throwsIllegalArgumentException() {
+        assertThatThrownBy(() -> SheetsClient.parseDate("2026-4-1", 5, "Sheet1"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Row 5")
+                .hasMessageContaining("Sheet1")
+                .hasMessageContaining("YYYY-MM-DD");
+    }
+
+    @Test
+    void parseDate_dateTimeFormat_throwsIllegalArgumentException() {
+        assertThatThrownBy(() -> SheetsClient.parseDate("2026-04-01T12:00:00Z", 3, "MySheet"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Row 3")
+                .hasMessageContaining("MySheet");
+    }
+
+    @Test
+    void parseDate_spreadsheetValue_throwsIllegalArgumentException() {
+        // Spreadsheet-formatted dates like "April 1, 2026" must be rejected
+        assertThatThrownBy(() -> SheetsClient.parseDate("April 1, 2026", 7, "Sheet1"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("YYYY-MM-DD");
+    }
+}

--- a/core/src/test/java/io/getskipper/core/SkipperResolverCacheTest.java
+++ b/core/src/test/java/io/getskipper/core/SkipperResolverCacheTest.java
@@ -1,0 +1,85 @@
+package io.getskipper.core;
+
+import io.getskipper.core.credentials.FileCredentials;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SkipperResolverCacheTest {
+
+    private static final SkipperConfig DUMMY_CONFIG = SkipperConfig.builder(
+            "dummy-spreadsheet-id",
+            new FileCredentials("./service-account-skipper-bot.json")).build();
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void writeThenRead_returnsEntries() throws Exception {
+        SkipperResolver resolver = new SkipperResolver(DUMMY_CONFIG);
+        String cacheFile = tempDir.resolve("cache.json").toString();
+
+        Instant futureDate = Instant.now().plus(1, ChronoUnit.DAYS).truncatedTo(ChronoUnit.SECONDS);
+        Map<String, Instant> entries = new HashMap<>();
+        entries.put("com/example/authtest.java > authtest > login", futureDate);
+        entries.put("com/example/authtest.java > authtest > logout", null);
+
+        resolver.writeCacheFile(cacheFile, entries);
+
+        Map<String, Instant> read = SkipperResolver.readCacheFile(cacheFile, 300);
+
+        assertThat(read).isNotNull();
+        assertThat(read).containsKey("com/example/authtest.java > authtest > login");
+        assertThat(read.get("com/example/authtest.java > authtest > login")).isEqualTo(futureDate);
+        assertThat(read).containsKey("com/example/authtest.java > authtest > logout");
+        assertThat(read.get("com/example/authtest.java > authtest > logout")).isNull();
+    }
+
+    @Test
+    void readCacheFile_missingFile_returnsNull() {
+        String cacheFile = tempDir.resolve("nonexistent.json").toString();
+        assertThat(SkipperResolver.readCacheFile(cacheFile, 300)).isNull();
+    }
+
+    @Test
+    void readCacheFile_expiredCache_returnsNull() throws Exception {
+        SkipperResolver resolver = new SkipperResolver(DUMMY_CONFIG);
+        String cacheFile = tempDir.resolve("cache.json").toString();
+
+        // Write a cache with a very old timestamp by writing raw JSON
+        String oldJson = "{\"savedAt\":\"2000-01-01T00:00:00Z\",\"entries\":{}}";
+        java.nio.file.Files.writeString(Path.of(cacheFile), oldJson);
+
+        // TTL of 300 seconds — the 25-year-old cache should be rejected
+        assertThat(SkipperResolver.readCacheFile(cacheFile, 300)).isNull();
+    }
+
+    @Test
+    void readCacheFile_withinTtl_returnsEntries() throws Exception {
+        SkipperResolver resolver = new SkipperResolver(DUMMY_CONFIG);
+        String cacheFile = tempDir.resolve("cache.json").toString();
+
+        Map<String, Instant> entries = new HashMap<>();
+        entries.put("com/example/test.java > test > method", null);
+        resolver.writeCacheFile(cacheFile, entries);
+
+        // With a generous TTL the cache should be returned
+        Map<String, Instant> result = SkipperResolver.readCacheFile(cacheFile, 3600);
+        assertThat(result).isNotNull();
+        assertThat(result).containsKey("com/example/test.java > test > method");
+    }
+
+    @Test
+    void isTestEnabled_afterFailOpen_allTestsRun() {
+        // Simulate the fail-open state: cache is empty (all tests should run)
+        SkipperResolver resolver = SkipperResolver.forTesting(DUMMY_CONFIG, java.util.List.of());
+        assertThat(resolver.isTestEnabled("any/test/AnyTest.java > AnyTest > anyMethod")).isTrue();
+    }
+}


### PR DESCRIPTION
Issue #3 — strict date parsing (SheetsClient):
- Only YYYY-MM-DD is accepted; any other format throws
  IllegalArgumentException with the row number and sheet name so bad
  spreadsheet data fails loudly at startup, not silently mid-run.
- The expiry instant is now the start of the *following* UTC day
  (date + 1 day at midnight UTC), making the disable-until boundary
  timezone-independent across all CI runners.
- Removed the multi-format fallback parsers; added 9 unit tests in
  SheetsClientDateParsingTest.

Issue #1 — safety trinity (SkipperResolver + SheetsWriter):
- SKIPPER_FAIL_OPEN (default true): when the Sheets API is unreachable
  and no valid cache exists, all tests run instead of the process
  crashing.
- SKIPPER_CACHE_FILE (default .skipper-cache.json) + SKIPPER_CACHE_TTL
  (default 300 s): successful fetches are persisted to disk and used as
  a fallback within the TTL window.
- SKIPPER_SYNC_ALLOW_DELETE (default false): SheetsWriter.sync() now
  detects orphaned rows and warns about them; actual deletion requires
  opting in via the env var. Rows are deleted via a single batchUpdate
  call in reverse-index order to avoid shifting.
- Added SkipperResolverCacheTest with 5 unit tests covering write/read
  round-trip, missing file, expired TTL, and fail-open semantics.

https://claude.ai/code/session_016isAj14n4LxGLoSMYyRA6V